### PR TITLE
EXT-1021: Different contrast threshold for border and text 

### DIFF
--- a/palette/src/components/Swatch.vue
+++ b/palette/src/components/Swatch.vue
@@ -7,21 +7,24 @@ const ink = '#1b243f'
 const divider = '#DFE3E8'
 const transparent = 'transparent'
 
-const shouldUseDarkColor = (hexColor) => {
-  const blackSRGB = { r: 0, g: 0, b: 0 }
-  const contrast = contrastRatio(
+const contrastThresholdBorder = 17
+const contrastThresholdText = 11
+
+const blackSRGB = { r: 0, g: 0, b: 0 }
+
+const hexColorContrast = (hexColor) =>
+  contrastRatio(
     relativeLuminance(hexToSRGB(hexColor) ?? blackSRGB),
     relativeLuminance(blackSRGB),
   )
-  console.log(contrast)
-  return contrast > 11
-}
 
 const contrastTextColor = (hexColor) => {
-  return shouldUseDarkColor(hexColor) ? ink : white
+  return hexColorContrast(hexColor) > contrastThresholdText ? ink : white
 }
 const contrastBorderColor = (hexColor) => {
-  return shouldUseDarkColor(hexColor) ? divider : transparent
+  return hexColorContrast(hexColor) > contrastThresholdBorder
+    ? divider
+    : transparent
 }
 
 export default {


### PR DESCRIPTION
## What

Fix for #16.

Using different contrast threshold for swatch border and swatch checkmark

<img width="306" alt="image" src="https://user-images.githubusercontent.com/14206504/224072428-a12bcd8d-2918-423f-8758-b2ab33e75448.png">

Also removing `console.log`.

## Why

Because the checkmark and border have different colors, it looks better if the border contrast threshold is higher than the checkmark's.