### PR TITLE
Continuous Step Size

### DIFF
--- a/slider/src/components/HorizontalSlider/HorizontalSlider.vue
+++ b/slider/src/components/HorizontalSlider/HorizontalSlider.vue
@@ -196,7 +196,9 @@ export default {
         this.maxValue,
         Math.max(unboundValue, this.minValue),
       )
-      const value = roundToNearest(boundValue, this.stepSize)
+      const value = this.stepSize
+        ? roundToNearest(boundValue, this.stepSize)
+        : boundValue
       this.setValue(value)
     },
     markPosition(mark) {

--- a/slider/src/components/HorizontalSlider/HorizontalSlider.vue
+++ b/slider/src/components/HorizontalSlider/HorizontalSlider.vue
@@ -123,7 +123,7 @@ export default {
     },
     stepSize: {
       type: Number,
-      default: 1,
+      default: 0,
     },
     marks: {
       type: Array,

--- a/slider/src/components/SliderPlugin.vue
+++ b/slider/src/components/SliderPlugin.vue
@@ -5,6 +5,7 @@
     :min-value="minValue"
     :max-value="maxValue"
     :marks="boundedMarks"
+    :step-size="1"
   />
 </template>
 


### PR DESCRIPTION
This allow the stepSize to be 0, which means that no rounding takes place.

- If the `stepSize` prop in `HorizontalSlider.vue` is `undefined`, the value defaults to `0`.
- `SliderPlugin.vue` still uses `1` as default, to maintain backwards compability. The app promises the user that the step is 1. So when we open up for users to change the stepSize, the spaces who are already using the slider should not be affected.

