### PR TITLE
feat(code-block): content as object

### DIFF
--- a/code-block/src/components/App.tsx
+++ b/code-block/src/components/App.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent } from 'react'
 import { useFieldPlugin } from '../useFieldPlugin'
-import { CodeMirror } from './CodeMirror'
+import { CodeEditor } from './CodeEditor'
+import { parseCodeEditorState } from './CodeEditor/CodeEditorContent'
 
 export const App: FunctionComponent = () => {
   const { type, data, actions, error } = useFieldPlugin()
@@ -14,12 +15,12 @@ export const App: FunctionComponent = () => {
     return <></>
   }
 
-  const content = typeof data.content === 'string' ? data.content : ''
+  const content = parseCodeEditorState(data.content)
 
   return (
-    <CodeMirror
-      initialValue={content}
-      onChange={(value) => actions.setContent(value)}
+    <CodeEditor
+      content={content}
+      setContent={actions.setContent}
     />
   )
 }

--- a/code-block/src/components/CodeEditor/CodeEditor.tsx
+++ b/code-block/src/components/CodeEditor/CodeEditor.tsx
@@ -1,0 +1,29 @@
+import { FunctionComponent } from 'react'
+import { CodeEditorContent } from './CodeEditorContent'
+import { CodeMirror } from '../CodeMirror'
+
+/**
+ * A simple code editor without syntax highlighting where the user can select rows in four states: default, highlight, add, remove,
+ * @param props
+ * @constructor
+ */
+export const CodeEditor: FunctionComponent<{
+  content: CodeEditorContent
+  setContent: (content: CodeEditorContent) => void
+}> = (props) => {
+  const { content, setContent } = props
+  const { code } = content
+
+  const onChange = (value: string) =>
+    setContent({
+      ...content,
+      code: value,
+    })
+
+  return (
+    <CodeMirror
+      initialValue={code}
+      onChange={onChange}
+    />
+  )
+}

--- a/code-block/src/components/CodeEditor/CodeEditorContent.tsx
+++ b/code-block/src/components/CodeEditor/CodeEditorContent.tsx
@@ -1,0 +1,18 @@
+import { z } from 'zod'
+
+const CodeEditorContentSchema = z.object({
+  code: z.string(),
+})
+
+export type CodeEditorContent = z.infer<typeof CodeEditorContentSchema>
+
+export const parseCodeEditorState = (data: unknown): CodeEditorContent => {
+  const content = CodeEditorContentSchema.safeParse(data)
+  if (content.success) {
+    return content.data
+  } else {
+    return {
+      code: '',
+    }
+  }
+}

--- a/code-block/src/components/CodeEditor/index.ts
+++ b/code-block/src/components/CodeEditor/index.ts
@@ -1,0 +1,1 @@
+export * from './CodeEditor'


### PR DESCRIPTION
## What

Changing the content type from `string` -> `{ code: string }`

<img width="748" alt="image" src="https://github.com/storyblok/field-type-examples/assets/14206504/15cd03a2-cb62-488c-b78b-4972e42a07dd">


## Why

In upcoming pull requests, more propertie will be added to this object. Thus, it is no longer sufficient to just store the content in a string.

## How to test

See the preview.