### PR TITLE
feat: custom starting line number 

### DIFF
--- a/code-block/src/components/CodeEditor/CodeEditor.tsx
+++ b/code-block/src/components/CodeEditor/CodeEditor.tsx
@@ -5,6 +5,7 @@ import { CodeMirror } from '../CodeMirror'
 import { mix } from './mix'
 import { sb_dark_blue, sb_dark_blue_50, white } from '../../design-tokens'
 import { css } from '@emotion/react'
+import { integerFromString } from '../../utils/numberFromString'
 import {
   defaultHighlightStateOption,
   HighlightStateOptions,
@@ -47,7 +48,15 @@ export const CodeEditor: FunctionComponent<{
     setContent({
       ...content,
       title: value === '' ? undefined : value,
-    })
+    } satisfies CodeEditorContent)
+  }
+
+  const setLineNumberOffset: ChangeEventHandler<HTMLInputElement> = (e) => {
+    const { value } = e.currentTarget
+    setContent({
+      ...content,
+      lineNumberStart: integerFromString(value),
+    } satisfies CodeEditorContent)
   }
 
   return (
@@ -63,26 +72,27 @@ export const CodeEditor: FunctionComponent<{
       <div
         css={css({
           display: 'flex',
+          alignItems: 'center',
           borderBottom: `1px solid rgb(141, 145, 159)`,
-          padding: '5px 15px',
+          padding: '7px 15px',
           backgroundColor: sb_dark_blue,
           color: white,
+          // Typography
+          fontSize: '12px',
+          fontFamily: 'Roboto, Helvetica, Arial, sans-serif',
+          fontWeight: 400,
+          lineHeight: '1.66',
+          letterSpacing: '0.03333em',
         })}
       >
         <input
+          id="title"
           css={css({
             flex: 1,
 
             color: 'inherit',
             backgroundColor: 'inherit',
             border: 'none',
-
-            margin: '0px',
-            fontSize: '12px',
-            fontFamily: 'Roboto, Helvetica, Arial, sans-serif',
-            fontWeight: 400,
-            lineHeight: '1.66',
-            letterSpacing: '0.03333em',
 
             '&:focus': {
               outline: 'none',
@@ -93,7 +103,41 @@ export const CodeEditor: FunctionComponent<{
           })}
           placeholder="Title"
           onChange={setTitle}
-          value={props.content.title}
+          value={content.title}
+        />
+        <label
+          css={css({
+            marginRight: '1ch',
+            color: sb_dark_blue_50,
+          })}
+          htmlFor="lineNumberStart"
+        >
+          Starts at:
+        </label>
+        <input
+          id="lineNumberStart"
+          type="number"
+          min={1}
+          css={css({
+            color: 'inherit',
+            backgroundColor: 'inherit',
+            border: 'none',
+            appearance: 'textfield',
+            width: '5ch',
+
+            '&:focus': {
+              outline: 'none',
+            },
+            '&::placeholder': {
+              color: sb_dark_blue_50,
+            },
+            '&::-webkit-inner-spin-button, &::-webkit-outer-spin-button': {
+              '-webkit-appearance': 'none',
+            },
+          })}
+          placeholder="1"
+          onChange={setLineNumberOffset}
+          value={content.lineNumberStart}
         />
       </div>
       <CodeMirror
@@ -120,6 +164,7 @@ export const CodeEditor: FunctionComponent<{
         onLineNumberClick={
           highlightStatesOption.length > 1 ? handleLineNumberClick : undefined
         }
+        lineNumberStart={content.lineNumberStart ?? 1}
       />
     </div>
   )

--- a/code-block/src/components/CodeEditor/CodeEditorContent.tsx
+++ b/code-block/src/components/CodeEditor/CodeEditorContent.tsx
@@ -4,6 +4,7 @@ const CodeEditorContentSchema = z.object({
   code: z.string(),
   highlightStates: z.array(z.string()),
   title: z.string().optional(),
+  lineNumberStart: z.number().optional(),
 })
 
 export type CodeEditorContent = z.infer<typeof CodeEditorContentSchema>

--- a/code-block/src/components/CodeMirror/CodeMirror.tsx
+++ b/code-block/src/components/CodeMirror/CodeMirror.tsx
@@ -29,8 +29,9 @@ export const CodeMirror: FunctionComponent<{
   initialValue: string
   onChange: (value: string, lineCount: number) => void
   onLineNumberClick?: (lineNumber: number) => void
+  lineNumberStart: number
 }> = (props) => {
-  const { initialValue } = props
+  const { initialValue, lineNumberStart } = props
   const parentRef = useRef<HTMLDivElement>(null)
 
   const onChange = useSyncedFunction(props.onChange)
@@ -50,6 +51,7 @@ export const CodeMirror: FunctionComponent<{
       parent: parentRef.current,
       extensions: [
         lineNumbers({
+          formatNumber: (lineNo) => (lineNo + lineNumberStart - 1).toString(10),
           domEventHandlers: {
             click: (view, line) => {
               const lineNumber = view.state.doc.lineAt(line.from).number - 1
@@ -66,7 +68,7 @@ export const CodeMirror: FunctionComponent<{
     return () => {
       editorView.dom.remove()
     }
-  }, [theme, enableClickableLineNumbers])
+  }, [theme, enableClickableLineNumbers, lineNumberStart])
 
   return (
     <div

--- a/code-block/src/utils/numberFromString/index.ts
+++ b/code-block/src/utils/numberFromString/index.ts
@@ -1,0 +1,1 @@
+export * from './integerFromString'

--- a/code-block/src/utils/numberFromString/integerFromString.test.ts
+++ b/code-block/src/utils/numberFromString/integerFromString.test.ts
@@ -1,0 +1,62 @@
+import { integerFromString } from './integerFromString'
+
+describe('numberFromString', () => {
+  it('should parse natural numbers', () => {
+    expect(integerFromString('123')).toEqual(123)
+  })
+  it('should parse integers', () => {
+    expect(integerFromString('123')).toEqual(123)
+    expect(integerFromString('-123')).toEqual(-123)
+  })
+  it('should not parse floating numbers', () => {
+    expect(integerFromString('1.5')).toBeUndefined
+  })
+  it('should not return infinity for large numbers', () => {
+    const googolStr = `1${new Array(1000).fill(0).join('')}`
+    expect(integerFromString(googolStr)).toBeUndefined()
+  })
+  it('should not return infinity for small numbers', () => {
+    const googolStr = `-1${new Array(1000).fill(0).join('')}`
+    expect(integerFromString(googolStr)).toBeUndefined()
+  })
+  it('parses hexadecimal values', () => {
+    expect(integerFromString('0xFF')).toBe(255)
+    expect(integerFromString('0x00')).toBe(0)
+    expect(integerFromString('0x0')).toBe(0)
+    expect(integerFromString('0x80')).toBe(128)
+  })
+  test('empty strings', () => {
+    expect(integerFromString('')).toBeUndefined()
+  })
+  describe('malformatted numbers', () => {
+    test('string with whitespace', () => {
+      expect(integerFromString(' ')).toBeUndefined()
+      expect(integerFromString('\r')).toBeUndefined()
+      expect(integerFromString('\n')).toBeUndefined()
+      expect(integerFromString('\n\r ')).toBeUndefined()
+    })
+    test('string with number and whitespace', () => {
+      expect(integerFromString('1 ')).toBeUndefined()
+      expect(integerFromString(' 1')).toBeUndefined()
+      expect(integerFromString(' 1 ')).toBeUndefined()
+      expect(integerFromString('\r 1')).toBeUndefined()
+      expect(integerFromString('\n 1')).toBeUndefined()
+      expect(integerFromString('\n\r 1')).toBeUndefined()
+    })
+    test('fractions', () => {
+      expect(integerFromString('1/2')).toBeUndefined()
+    })
+    test('text followed by numbers', () => {
+      expect(integerFromString('hello123')).toBeUndefined()
+    })
+    test('numbers followed by text', () => {
+      expect(integerFromString('123hello')).toBeUndefined()
+    })
+    test('numbers in text', () => {
+      expect(integerFromString('hello123hello')).toBeUndefined()
+    })
+    test('text', () => {
+      expect(integerFromString('hello')).toBeUndefined()
+    })
+  })
+})

--- a/code-block/src/utils/numberFromString/integerFromString.ts
+++ b/code-block/src/utils/numberFromString/integerFromString.ts
@@ -1,0 +1,18 @@
+/**
+ * Parses an integer from a string without any suprises. Strings that describe numbers without any other characters yield
+ * `number`. All other combination of characters yield `undefined`.
+ */
+export const integerFromString = (str: string): number | undefined => {
+  const parsed = parseInt(str)
+  return str !== '' && !hasWhiteSpace(str) && !isNaN(parsed) && isFinite(parsed)
+    ? parsed
+    : undefined
+}
+
+/**
+ * @param str
+ * @returns `true` if any character is a whitespace.
+ */
+const hasWhiteSpace = (str: string): boolean => {
+  return /\s+/.test(str)
+}


### PR DESCRIPTION
Issue: EXT-1549

## What

Allows the content editors to change the starting line number.

By default, the line number is `undefined` and that starts it at `1`:

<img width="638" alt="image" src="https://github.com/storyblok/field-type-examples/assets/14206504/b15b12fa-e17e-44ae-8166-2d18f7ef2f3e">

<img width="667" alt="image" src="https://github.com/storyblok/field-type-examples/assets/14206504/dbb72f10-083e-45d1-9a00-cb493eb89df1">


The content editor can type in the top right corner and that changes the starting line number:

<img width="652" alt="image" src="https://github.com/storyblok/field-type-examples/assets/14206504/b4b77e91-be23-4b35-8c7b-0ebbd43ff95d">

<img width="676" alt="image" src="https://github.com/storyblok/field-type-examples/assets/14206504/f6e9d3f6-9b47-4228-b231-92e77647853a">


## How to test

See the preview

Please test in Firefox and Chrome, because there are some webkit-specific styles.
