### PR TITLE
fix: Initiate content.highlightStates with one element

### DIFF
--- a/code-block/src/components/CodeEditor/CodeEditorContent.tsx
+++ b/code-block/src/components/CodeEditor/CodeEditorContent.tsx
@@ -14,7 +14,7 @@ export const parseCodeEditorState = (data: unknown): CodeEditorContent => {
   if (!content.success) {
     return {
       code: '',
-      highlightStates: [],
+      highlightStates: [''],
     }
   }
 


### PR DESCRIPTION
Issue: EXT-1637

## What?

Initiate content.highlightStates with one element
## Why?

When the content is initially set, the highlightStates array should contain one element, because the code always has at least one line.

This solves a bug where the first line could not be selected the very first time the plugin is opened (while the saved content is `""` and the default value is used).

## How to test? (optional)

Open the preview deployment, add an option (without interacting with the plugin).