### PR TITLE
feat: label for every header input

### DIFF
--- a/code-block/README.md
+++ b/code-block/README.md
@@ -65,4 +65,4 @@ Example output:
 
 Given that `options.highlightStates` were configured as in the example above.
 
-Note that all properties except `code` are optional
+Note that all properties except `code` are optional.


### PR DESCRIPTION
Issue: EXT-1650

## What?

Labels for every header input:

<img width="527" alt="image" src="https://github.com/storyblok/field-type-examples/assets/14206504/e3a7a407-f6a6-44e7-9f28-c83a918ced54">

No values:

<img width="534" alt="image" src="https://github.com/storyblok/field-type-examples/assets/14206504/08852ca0-8668-4b26-bbb0-ef99e8759d52">

Focused:

<img width="527" alt="image" src="https://github.com/storyblok/field-type-examples/assets/14206504/e3d90258-3db9-4d88-b270-d57f2b5d1408">


Hover:

<img width="524" alt="image" src="https://github.com/storyblok/field-type-examples/assets/14206504/cf737544-0139-4db2-a14f-b21e7f7374e6">


Responsive:

![2023-05-30_13-34-51 (1)](https://github.com/storyblok/field-type-examples/assets/14206504/caf586fa-cd49-466b-a089-625c611384f2)

Works with different combinations of header inputs:

![2023-05-30_13-36-01 (1)](https://github.com/storyblok/field-type-examples/assets/14206504/859242cf-9021-43a0-9eaf-4da019a7b6c3)


## Why?

Before, it was difficult to distinguish between the inputs, because only the input placeholder was there to indicate which field is which, but as soon as you type something, that placeholder disappears.

![image](https://github.com/storyblok/field-type-examples/assets/14206504/c52b75ef-5aa0-4501-b86b-3b3c5e372fcc)

See [this comment](https://storyblok.atlassian.net/browse/EXT-1335?focusedCommentId=42744).

## How to test? (optional)

Combine different:

- Screen widths

With different combinations of 

- enableLineNumberStart
- enableTitle
- enableLanguage