### PR TITLE
ci: fix deploy action

### DIFF
--- a/.github/workflows/code-block.yml
+++ b/.github/workflows/code-block.yml
@@ -30,7 +30,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    depends-on: build
+    needs: build
     if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
ci: fix deploy action.

property is called `needs`, not `depends-on`