### PR TITLE
feat: omit `content.highlightStates` when `options.highlightStates` is omitted.

### DIFF
--- a/code-block/src/Options.ts
+++ b/code-block/src/Options.ts
@@ -11,7 +11,7 @@ const RawOptionsSchema = z.object({
 type RawOptionsOptions = z.infer<typeof RawOptionsSchema>
 
 export type CodeBlockOptions = {
-  highlightStates: HighlightStateOptions
+  highlightStates?: HighlightStateOptions
   enableTitle: boolean
   enableLineNumberStart: boolean
   enableLanguage: boolean
@@ -40,12 +40,12 @@ export const defaultHighlightStateOption = {
 
 const highlightStatesOptionFromOptions = (
   rawOptions: RawOptionsOptions,
-): HighlightStateOptions | Error => {
+): HighlightStateOptions | undefined | Error => {
   if (
     typeof rawOptions.highlightStates === 'undefined' ||
     rawOptions.highlightStates === ''
   ) {
-    return [defaultHighlightStateOption]
+    return undefined
   }
   try {
     const highlightStates = HighlightStateOptionSchema.safeParse(

--- a/code-block/src/components/CodeEditor/CodeEditor.tsx
+++ b/code-block/src/components/CodeEditor/CodeEditor.tsx
@@ -1,13 +1,13 @@
-import { FunctionComponent, useCallback, useMemo } from 'react'
+import { FunctionComponent, useCallback } from 'react'
 import { CodeEditorContent } from './CodeEditorContent'
-import { toggleLine } from './toggleLine'
 import { CodeMirror } from '../CodeMirror'
 import { mix } from './mix'
 import { css } from '@emotion/react'
-import { CodeBlockOptions, defaultHighlightStateOption } from '../../Options'
+import { CodeBlockOptions } from '../../Options'
 import { colorFromHighlightState } from './colorFromHighlightState'
-import { withLength } from '../../utils'
 import { CodeEditorHeader } from './CodeEditorHeader'
+import { onLineClickSetAction } from './onLineClickSetAction'
+import { onChangeSetAction } from './onChangeSetAction'
 
 /**
  * A simple code editor without syntax highlighting where the user can select rows in four states: default, highlight, add, remove,
@@ -109,42 +109,3 @@ export const CodeEditor: FunctionComponent<{
     </div>
   )
 }
-
-const onChangeSetAction =
-  (
-    options: CodeBlockOptions['highlightStates'],
-    value: string,
-    lineCount: number,
-  ) =>
-  (content: CodeEditorContent): CodeEditorContent => ({
-    ...content,
-    code: value,
-    highlightStates: options
-      ? withLength(
-          content.highlightStates ?? [],
-          lineCount,
-          defaultHighlightStateOption.value,
-        )
-      : undefined,
-  })
-
-const onLineClickSetAction =
-  (
-    options: CodeBlockOptions['highlightStates'],
-    lineCount: number,
-    line: number,
-  ) =>
-  (content: CodeEditorContent): CodeEditorContent => ({
-    ...content,
-    highlightStates: options
-      ? toggleLine(
-          options,
-          withLength(
-            content.highlightStates ?? [],
-            lineCount,
-            defaultHighlightStateOption.value,
-          ),
-          line,
-        )
-      : undefined,
-  })

--- a/code-block/src/components/CodeEditor/CodeEditor.tsx
+++ b/code-block/src/components/CodeEditor/CodeEditor.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent } from 'react'
+import { FunctionComponent, useCallback, useMemo } from 'react'
 import { CodeEditorContent } from './CodeEditorContent'
 import { toggleLine } from './toggleLine'
 import { CodeMirror } from '../CodeMirror'
@@ -23,34 +23,18 @@ export const CodeEditor: FunctionComponent<{
 }> = (props) => {
   const { setContent, options } = props
 
-  const onChange = (value: string, lineCount: number) =>
-    setContent((content) => ({
-      ...content,
-      code: value,
-      highlightStates: options.highlightStates
-        ? withLength(
-            content.highlightStates ?? [],
-            lineCount,
-            defaultHighlightStateOption.value,
-          )
-        : undefined,
-    }))
-
-  const handleLineNumberClick = (line: number, lineCount: number) =>
-    setContent((content) => ({
-      ...content,
-      highlightStates: options.highlightStates
-        ? toggleLine(
-            options.highlightStates,
-            withLength(
-              content.highlightStates ?? [],
-              lineCount,
-              defaultHighlightStateOption.value,
-            ),
-            line,
-          )
-        : undefined,
-    }))
+  const onChange = useCallback(
+    (value: string, lineCount: number) =>
+      setContent(onChangeSetAction(options.highlightStates, value, lineCount)),
+    [options.highlightStates],
+  )
+  const handleLineNumberClick = useCallback(
+    (line: number, lineCount: number) =>
+      setContent(
+        onLineClickSetAction(options.highlightStates, lineCount, line),
+      ),
+    [options.highlightStates],
+  )
 
   const handleTitleChange = (title: string | undefined) =>
     setContent((content) => ({
@@ -125,3 +109,42 @@ export const CodeEditor: FunctionComponent<{
     </div>
   )
 }
+
+const onChangeSetAction =
+  (
+    options: CodeBlockOptions['highlightStates'],
+    value: string,
+    lineCount: number,
+  ) =>
+  (content: CodeEditorContent): CodeEditorContent => ({
+    ...content,
+    code: value,
+    highlightStates: options
+      ? withLength(
+          content.highlightStates ?? [],
+          lineCount,
+          defaultHighlightStateOption.value,
+        )
+      : undefined,
+  })
+
+const onLineClickSetAction =
+  (
+    options: CodeBlockOptions['highlightStates'],
+    lineCount: number,
+    line: number,
+  ) =>
+  (content: CodeEditorContent): CodeEditorContent => ({
+    ...content,
+    highlightStates: options
+      ? toggleLine(
+          options,
+          withLength(
+            content.highlightStates ?? [],
+            lineCount,
+            defaultHighlightStateOption.value,
+          ),
+          line,
+        )
+      : undefined,
+  })

--- a/code-block/src/components/CodeEditor/CodeEditor.tsx
+++ b/code-block/src/components/CodeEditor/CodeEditor.tsx
@@ -27,21 +27,29 @@ export const CodeEditor: FunctionComponent<{
     setContent((content) => ({
       ...content,
       code: value,
-      highlightStates: withLength(
-        content.highlightStates,
-        lineCount,
-        defaultHighlightStateOption.value,
-      ),
+      highlightStates: options.highlightStates
+        ? withLength(
+            content.highlightStates ?? [],
+            lineCount,
+            defaultHighlightStateOption.value,
+          )
+        : undefined,
     }))
 
-  const handleLineNumberClick = (line: number) =>
+  const handleLineNumberClick = (line: number, lineCount: number) =>
     setContent((content) => ({
       ...content,
-      highlightStates: toggleLine(
-        options.highlightStates,
-        content.highlightStates,
-        line,
-      ),
+      highlightStates: options.highlightStates
+        ? toggleLine(
+            options.highlightStates,
+            withLength(
+              content.highlightStates ?? [],
+              lineCount,
+              defaultHighlightStateOption.value,
+            ),
+            line,
+          )
+        : undefined,
     }))
 
   const handleTitleChange = (title: string | undefined) =>
@@ -85,27 +93,32 @@ export const CodeEditor: FunctionComponent<{
       />
       <CodeMirror
         css={css(
-          props.content.highlightStates.map((state, index) => ({
-            [`.cm-gutterElement:nth-of-type(${index + 2})`]: {
-              backgroundColor: mix(
-                colorFromHighlightState(options.highlightStates, state),
-                'transparent',
-                0.5,
-              ),
-            },
-            [`.cm-line:nth-of-type(${index + 1})`]: {
-              backgroundColor: mix(
-                colorFromHighlightState(options.highlightStates, state),
-                'transparent',
-                0.25,
-              ),
-            },
-          })),
+          props.content.highlightStates?.map(
+            (state, index) =>
+              options.highlightStates && {
+                [`.cm-gutterElement:nth-of-type(${index + 2})`]: {
+                  backgroundColor: mix(
+                    colorFromHighlightState(options.highlightStates, state),
+                    'transparent',
+                    0.5,
+                  ),
+                },
+                [`.cm-line:nth-of-type(${index + 1})`]: {
+                  backgroundColor: mix(
+                    colorFromHighlightState(options.highlightStates, state),
+                    'transparent',
+                    0.25,
+                  ),
+                },
+              },
+          ),
         )}
         initialValue={props.content.code}
         onChange={onChange}
         onLineNumberClick={
-          options.highlightStates.length > 1 ? handleLineNumberClick : undefined
+          options.highlightStates && options.highlightStates.length > 1
+            ? handleLineNumberClick
+            : undefined
         }
         lineNumberStart={props.content.lineNumberStart ?? 1}
       />

--- a/code-block/src/components/CodeEditor/CodeEditorContent.tsx
+++ b/code-block/src/components/CodeEditor/CodeEditorContent.tsx
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 const CodeEditorContentSchema = z.object({
   code: z.string(),
-  highlightStates: z.array(z.string()),
+  highlightStates: z.array(z.string()).optional(),
   title: z.string().optional(),
   language: z.string().optional(),
   lineNumberStart: z.number().optional(),
@@ -15,11 +15,11 @@ export const parseCodeEditorState = (data: unknown): CodeEditorContent => {
   if (!content.success) {
     return {
       code: '',
-      highlightStates: [''],
     }
   }
 
   return content.data
 }
 
-export type HighlightState = CodeEditorContent['highlightStates'][number]
+export type HighlightState =
+  Required<CodeEditorContent>['highlightStates'][number]

--- a/code-block/src/components/CodeEditor/onChangeSetAction.test.ts
+++ b/code-block/src/components/CodeEditor/onChangeSetAction.test.ts
@@ -1,0 +1,117 @@
+import { onChangeSetAction } from './onChangeSetAction'
+import { CodeEditorContent } from './CodeEditorContent'
+import { CodeBlockOptions, defaultHighlightStateOption } from '../../Options'
+
+const options: CodeBlockOptions['highlightStates'] = [
+  defaultHighlightStateOption,
+  {
+    value: 'neutral',
+    color: 'yellow',
+  },
+  {
+    value: 'add',
+    color: 'green',
+  },
+  {
+    value: 'remove',
+    color: 'red',
+  },
+]
+
+describe('onChangeSetAction', () => {
+  describe('other properties', () => {
+    it('preserves other properties', () => {
+      const content: CodeEditorContent = {
+        code: '',
+        highlightStates: [''],
+        title: 'a title',
+        language: 'js',
+        lineNumberStart: 2,
+      }
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { code, highlightStates, ...otherContent } = content
+      expect(onChangeSetAction(undefined, 'any content', 4)(content)).toEqual(
+        expect.objectContaining(otherContent),
+      )
+    })
+  })
+  describe('code', () => {
+    it('sets the code', () => {
+      const content: CodeEditorContent = {
+        code: '',
+      }
+      expect(
+        onChangeSetAction(undefined, 'new content', 1)(content).code,
+      ).toEqual('new content')
+    })
+  })
+  describe('highlightStates', () => {
+    it('becomes undefined when options.highlightStates is undefined', () => {
+      const content: CodeEditorContent = {
+        code: '',
+        highlightStates: [],
+      }
+      expect(
+        onChangeSetAction(undefined, 'new content', 1)(content).highlightStates,
+      ).toBeUndefined()
+    })
+    it('becomes defined when options.highlightStates is defined', () => {
+      const content: CodeEditorContent = {
+        code: '',
+      }
+      expect(
+        onChangeSetAction(options, 'new content', 1)(content).highlightStates,
+      ).toBeDefined()
+    })
+    it('has the same length as the number of lines as the editor', () => {
+      const content: CodeEditorContent = {
+        code: '',
+        highlightStates: [],
+      }
+      expect(
+        onChangeSetAction(options, 'new content', 5)(content).highlightStates,
+      ).toHaveLength(5)
+      expect(
+        onChangeSetAction(options, 'new content', 1)(content).highlightStates,
+      ).toHaveLength(1)
+    })
+    it('extends to the same number of lines as the editor', () => {
+      const content: CodeEditorContent = {
+        code: '',
+        highlightStates: ['existingState'],
+      }
+      const newContent = onChangeSetAction(
+        options,
+        'new content',
+        2,
+      )(content).highlightStates
+      expect(newContent?.[0]).toEqual('existingState')
+      expect(newContent).toHaveLength(2)
+    })
+    it('shortens to the same number of lines as the editor', () => {
+      const content: CodeEditorContent = {
+        code: '',
+        highlightStates: ['a', 'b', 'c'],
+      }
+      const newContent = onChangeSetAction(
+        options,
+        'new content',
+        2,
+      )(content).highlightStates
+      expect(newContent).toEqual(['a', 'b'])
+    })
+    it('does not change when the line count is preserved', () => {
+      const highlightStates = ['a', 'b', 'c']
+      const content: CodeEditorContent = {
+        code: '',
+        highlightStates,
+      }
+      const newContent = onChangeSetAction(
+        [defaultHighlightStateOption],
+        'new content',
+        3,
+      )(content).highlightStates
+      expect(newContent).toBe(highlightStates)
+    })
+  })
+})

--- a/code-block/src/components/CodeEditor/onChangeSetAction.tsx
+++ b/code-block/src/components/CodeEditor/onChangeSetAction.tsx
@@ -1,0 +1,21 @@
+import { CodeBlockOptions, defaultHighlightStateOption } from '../../Options'
+import { CodeEditorContent } from './CodeEditorContent'
+import { withLength } from '../../utils'
+
+export const onChangeSetAction =
+  (
+    options: CodeBlockOptions['highlightStates'],
+    value: string,
+    lineCount: number,
+  ) =>
+  (content: CodeEditorContent): CodeEditorContent => ({
+    ...content,
+    code: value,
+    highlightStates: options
+      ? withLength(
+          content.highlightStates ?? [],
+          lineCount,
+          defaultHighlightStateOption.value,
+        )
+      : undefined,
+  })

--- a/code-block/src/components/CodeEditor/onLineClickSetAction.test.ts
+++ b/code-block/src/components/CodeEditor/onLineClickSetAction.test.ts
@@ -1,0 +1,139 @@
+import { CodeEditorContent } from './CodeEditorContent'
+import { CodeBlockOptions, defaultHighlightStateOption } from '../../Options'
+import { onLineClickSetAction } from './onLineClickSetAction'
+
+const code = 'dummy code'
+
+const options: CodeBlockOptions['highlightStates'] = [
+  defaultHighlightStateOption,
+  {
+    value: 'neutral',
+    color: 'yellow',
+  },
+  {
+    value: 'add',
+    color: 'green',
+  },
+  {
+    value: 'remove',
+    color: 'red',
+  },
+]
+
+describe('onChangeSetAction', () => {
+  describe('other properties', () => {
+    it('preserves other properties', () => {
+      const content: CodeEditorContent = {
+        code,
+        highlightStates: [''],
+        title: 'a title',
+        language: 'js',
+        lineNumberStart: 2,
+      }
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { highlightStates, ...otherContent } = content
+      expect(onLineClickSetAction(undefined, 4, 2)(content)).toEqual(
+        expect.objectContaining(otherContent),
+      )
+    })
+  })
+  describe('highlightStates', () => {
+    it('becomes undefined when options.highlightStates is undefined', () => {
+      const content: CodeEditorContent = {
+        code,
+        highlightStates: [],
+      }
+      expect(
+        onLineClickSetAction(undefined, 2, 1)(content).highlightStates,
+      ).toBeUndefined()
+    })
+    it('becomes defined when options.highlightStates is defined', () => {
+      const content: CodeEditorContent = {
+        code: '',
+      }
+      expect(
+        onLineClickSetAction(options, 3, 1)(content).highlightStates,
+      ).toBeDefined()
+    })
+    it('has the same length as the number of lines as the editor', () => {
+      const content: CodeEditorContent = {
+        code: '',
+        highlightStates: [],
+      }
+      expect(
+        onLineClickSetAction(options, 5, 2)(content).highlightStates,
+      ).toHaveLength(5)
+      expect(
+        onLineClickSetAction(options, 1, 0)(content).highlightStates,
+      ).toHaveLength(1)
+    })
+    it('extends to the same number of lines as the editor', () => {
+      const content: CodeEditorContent = {
+        code: '',
+        highlightStates: ['existingState'],
+      }
+      const newContent = onLineClickSetAction(
+        options,
+        2,
+        1,
+      )(content).highlightStates
+      expect(newContent?.[0]).toEqual('existingState')
+      expect(newContent).toHaveLength(2)
+    })
+    it('shortens to the same number of lines as the editor', () => {
+      const content: CodeEditorContent = {
+        code: '',
+        highlightStates: ['a', 'b', 'c'],
+      }
+      const newContent = onLineClickSetAction(
+        options,
+        2,
+        1,
+      )(content).highlightStates
+      expect(newContent).toHaveLength(2)
+    })
+    it('preserves the length when the line count does not change', () => {
+      const content: CodeEditorContent = {
+        code: '',
+        highlightStates: ['a', 'b', 'c'],
+      }
+      const newContent = onLineClickSetAction(
+        options,
+        3,
+        1,
+      )(content).highlightStates
+      expect(newContent).toHaveLength(3)
+    })
+    it('toggles the clicked line', () => {
+      const highlightStates = ['', '', '']
+      const content: CodeEditorContent = {
+        code: '',
+        highlightStates,
+      }
+      const options: CodeBlockOptions['highlightStates'] = [
+        {
+          value: '',
+          color: 'transparent',
+        },
+        {
+          value: 'neutral',
+          color: 'yellow',
+        },
+      ]
+      // toggle start, middle, and end
+      const toggleLine1 = onLineClickSetAction(options, 3, 0)
+      const toggleLine2 = onLineClickSetAction(options, 3, 1)
+      const toggleLine3 = onLineClickSetAction(options, 3, 2)
+      expect(toggleLine1(content).highlightStates).toEqual(['neutral', '', ''])
+      expect(toggleLine2(content).highlightStates).toEqual(['', 'neutral', ''])
+      expect(toggleLine3(content).highlightStates).toEqual(['', '', 'neutral'])
+
+      // cycles back to default value
+      expect(toggleLine1(toggleLine1(content)).highlightStates).toEqual([
+        '',
+        '',
+        '',
+      ])
+    })
+  })
+})

--- a/code-block/src/components/CodeEditor/onLineClickSetAction.tsx
+++ b/code-block/src/components/CodeEditor/onLineClickSetAction.tsx
@@ -1,0 +1,25 @@
+import { CodeBlockOptions, defaultHighlightStateOption } from '../../Options'
+import { CodeEditorContent } from './CodeEditorContent'
+import { toggleLine } from './toggleLine'
+import { withLength } from '../../utils'
+
+export const onLineClickSetAction =
+  (
+    options: CodeBlockOptions['highlightStates'],
+    lineCount: number,
+    line: number,
+  ) =>
+  (content: CodeEditorContent): CodeEditorContent => ({
+    ...content,
+    highlightStates: options
+      ? toggleLine(
+          options,
+          withLength(
+            content.highlightStates ?? [],
+            lineCount,
+            defaultHighlightStateOption.value,
+          ),
+          line,
+        )
+      : undefined,
+  })

--- a/code-block/src/components/CodeMirror/CodeMirror.tsx
+++ b/code-block/src/components/CodeMirror/CodeMirror.tsx
@@ -28,7 +28,7 @@ export const CodeMirror: FunctionComponent<{
   className?: string
   initialValue: string
   onChange: (value: string, lineCount: number) => void
-  onLineNumberClick?: (lineNumber: number) => void
+  onLineNumberClick?: (lineNumber: number, lineCount: number) => void
   lineNumberStart: number
 }> = (props) => {
   const { initialValue, lineNumberStart } = props
@@ -54,8 +54,9 @@ export const CodeMirror: FunctionComponent<{
           formatNumber: (lineNo) => (lineNo + lineNumberStart - 1).toString(10),
           domEventHandlers: {
             click: (view, line) => {
-              const lineNumber = view.state.doc.lineAt(line.from).number - 1
-              onLineNumberClick(lineNumber)
+              const { doc } = view.state
+              const lineNumber = doc.lineAt(line.from).number - 1
+              onLineNumberClick(lineNumber, doc.lines)
               return true
             },
           },


### PR DESCRIPTION
Issue: EXT-1618

## What?

When the title, lineNumberStart, or language are disabled by omitting the options, the corresponding values in the content are omitted. Similarly, this pull request omits `content.highlightStates` when `options.highlightStates` is omitted.

## Why?

So that each option is completely optional. When an option is disabled, the output should not be affected.

## How to test? (optional)

Type content without enabling `options.highlightStates`; `content.highlightStates` should be undefined:

<img width="697" alt="image" src="https://github.com/storyblok/field-type-examples/assets/14206504/d9cd094b-316e-4411-871f-488771da6ba7">

Type content while enabling `options.highlightStates`; `content.highlightStates` should be defined:

example: `highlightStates` - `[{"value":"wew","color":"orange"}]` 

Clicking the line number should also always highlight the row, even if the content was not initialized:

![2023-05-30_16-38-18 (1)](https://github.com/storyblok/field-type-examples/assets/14206504/6b55b5af-e14e-421f-a364-c920288470fb)




Enable the option