### PR TITLE
feat: replace `enableLanguage` with `languages`

### DIFF
--- a/code-block/README.md
+++ b/code-block/README.md
@@ -29,7 +29,11 @@ In the Block Library, select a block to edit. Add a new field, set the _Field Ty
 Configure the options:
 
 - `enableTitle`: (optional) if set to `true`, users can provide a title (`content.title`).
-- `enableLanguage`: (optional) if set to `true`, users can provide a language (`content.language`).
+- `languages`: (optional) a JSON array of strings. The strings are the languages that the user can choose between.
+  ```json
+  ["JavaScript", "TypeScript", "Elm", "Vue", "Rust", "JSON"]
+  ```
+  The options will be sorted alphabetically. If this option is omitted, the language select input is hidden.
 - `enableLineNumberStart`: (optional) if set to `true`, users can change the starting line numbers (`content.lineNumberStart`).
 - `highlightStates`: (optional) A JSON array of objects. Each object has two properties: `value` (`string`) and `color` (`string`). For example:
   ```json

--- a/code-block/src/components/CodeEditor/CodeEditor.tsx
+++ b/code-block/src/components/CodeEditor/CodeEditor.tsx
@@ -72,7 +72,7 @@ export const CodeEditor: FunctionComponent<{
         lineNumberStart={props.content.lineNumberStart}
         onLineNumberStartChange={handleLineNumberStartChange}
         enableTitle={options.enableTitle}
-        enableLanguage={options.enableLanguage}
+        languages={options.languages}
         enableLineNumberStart={options.enableLineNumberStart}
       />
       <CodeMirror


### PR DESCRIPTION
Issue: EXT-1651

## What?

Replaces the `enableLanguage` option with `languages`, allowing admins to restrict the languages that can be chosen.

## Why?

Without this feature, users would need to know the exact key/name for the programming languages. For example, what if they write "js", yet the highlighter in their documentation site expects "JavaScript"?

Also, syntax highlighting will not be set up for every language as that would increase the bundle size too much. 

## How to test?

Set the option `languages` to

```json
["js", "java", "kotlin", "Elm", "Haskell"]
```

The header should appear.

The language header should become enabled.

The list of options should be sorted.

The user should be able to de-select the language.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->