### PR TITLE
fix(code-block): increase highlighted gutter text contrast.

### DIFF
--- a/code-block/src/components/CodeEditor/CodeEditor.tsx
+++ b/code-block/src/components/CodeEditor/CodeEditor.tsx
@@ -3,11 +3,12 @@ import { CodeEditorContent } from './CodeEditorContent'
 import { CodeMirror } from '../CodeMirror'
 import { mix } from './mix'
 import { css } from '@emotion/react'
-import { CodeBlockOptions } from '../../Options'
+import { CodeBlockOptions, defaultHighlightStateOption } from '../../Options'
 import { colorFromHighlightState } from './colorFromHighlightState'
 import { CodeEditorHeader } from './CodeEditorHeader'
 import { onLineClickSetAction } from './onLineClickSetAction'
 import { onChangeSetAction } from './onChangeSetAction'
+import { sb_dark_blue } from '../../storyblok-design'
 
 /**
  * A simple code editor without syntax highlighting where the user can select rows in four states: default, highlight, add, remove,
@@ -79,8 +80,11 @@ export const CodeEditor: FunctionComponent<{
         css={css(
           props.content.highlightStates?.map(
             (state, index) =>
-              options.highlightStates && {
+              options.highlightStates &&
+              state !==
+                defaultHighlightStateOption(options.highlightStates).value && {
                 [`.cm-gutterElement:nth-of-type(${index + 2})`]: {
+                  color: sb_dark_blue,
                   backgroundColor: mix(
                     colorFromHighlightState(options.highlightStates, state),
                     'transparent',


### PR DESCRIPTION
Issue: EXT-1671

## What?

Increasing the contrast between the gutter background and text for highlighted lines.

Old:
<img width="648" alt="image" src="https://github.com/storyblok/field-type-examples/assets/14206504/27d534a9-42d6-4174-a47e-3cc2c7cab7d0">

New:
<img width="636" alt="image" src="https://github.com/storyblok/field-type-examples/assets/14206504/2761164d-3a79-4255-afdf-9dbd3f6ea55e">

## Why?

The contrast was too low.

## How to test? (optional)

Use the options described in the README:

`highlightStates`

```json
  [
    {
      "value": "",
      "color": "transparent"
    },
    {
      "value": "attention",
      "color": "#fbce41"
    },
    {
      "value": "add",
      "color": "#2db47d"
    },
    {
      "value": "remove",
      "color": "#ff6159"
    }
  ]
  ```

Then try the preview