### PR TITLE
fix(slider): do not fall back to defaultValue when value is 0

### DIFF
--- a/slider/src/components/SliderPlugin.vue
+++ b/slider/src/components/SliderPlugin.vue
@@ -67,9 +67,6 @@ export default {
         (mark) => mark > this.minValue && mark < this.maxValue,
       )
     },
-    selectedValue() {
-      return this.value?.value ?? this.defaultValue
-    },
     defaultValue() {
       return numberFromString(this.options.defaultValue) ?? this.minValue
     },
@@ -87,9 +84,14 @@ export default {
         return undefined
       }
     },
+    selectedValue() {
+      return typeof this.value?.value === 'number'
+        ? this.value.value
+        : this.defaultValue
+    },
   },
   created() {
-    if (!this.value?.value) {
+    if (typeof this.value?.value !== 'number') {
       this.setValue({ value: this.defaultValue })
     }
   },


### PR DESCRIPTION
Issue: EXT-1798

## What?

When the value is a number, the default value should not be applied. However, with the current approach, `0` is evaluated to `false`  in two if-statements which causes the plugin to use the default value for this special case.

## How to test? (optional)

Open this repository in a terminal

```
cd slider
nvm use 14
yarn dev
```