### PR TITLE
style(Tags): Adjust layout to match Blok.ink

### DIFF
--- a/tags/src/components/Tag.tsx
+++ b/tags/src/components/Tag.tsx
@@ -48,7 +48,7 @@ const renderTagItem = (
     // eslint-disable-next-line react/jsx-key
     <Chip
       label={option}
-      color="primary"
+      color="default"
       variant="filled"
       {...getTagProps({ index })}
     />


### PR DESCRIPTION
Issue: EXT-1873

## What?
It adjusts the component to match the same style as used in Blok.Ink theme.

![image](https://github.com/storyblok/field-type-examples/assets/1240591/b281216e-7bf5-4057-ae16-107f513a229b)

## Why?
In order to keep consistent in our visual editor layout, all new component needs to follow the same guidances/styles defined in Blok.ink theme.

## How to test? (optional)
You can test in the sandbox/field plugin editor.
You can build the app and see if it works in the Visual Editor.