### PR TITLE
feat(picker-starter): show pagination component only when needed

### DIFF
--- a/picker-starter/src/components/ItemPicker/utils/mixin/showPagePagination.ts
+++ b/picker-starter/src/components/ItemPicker/utils/mixin/showPagePagination.ts
@@ -1,6 +1,8 @@
+import { defaultPerPage } from '@/settings'
 import { State } from '../state/types/State'
 import { isPagePaginatedResult } from '@/core'
 
 export const showPagePagination = (state: State): boolean =>
   isPagePaginatedResult(state.pageInfo) &&
-  typeof state.pageInfo.totalCount !== 'undefined'
+  Number.isInteger(state.pageInfo.totalCount) &&
+  state.pageInfo.totalCount > defaultPerPage

--- a/picker-starter/src/data/categories.ts
+++ b/picker-starter/src/data/categories.ts
@@ -1,5 +1,5 @@
 import { CategoryItem, ItemQuery } from '@/core'
-import { compareName, delayed, randomDelay } from '@/utils'
+import { compareName, delayed, getPage, randomDelay } from '@/utils'
 
 export type MockCategory = {
   name: string
@@ -55,9 +55,10 @@ const allCategories: CategoryItem[] = categoryMockAssets
   )
   .sort(compareName)
 
-export const queryCategories: ItemQuery = async () => {
+export const queryCategories: ItemQuery = async ({ page, perPage }) => {
+  const paginatedResults = getPage(allCategories, page, perPage)
   const response = {
-    items: allCategories,
+    items: paginatedResults,
     pageInfo: {
       totalCount: allCategories.length,
     },


### PR DESCRIPTION
Issue: EXT-2109

## What?
The pagination component appears only when there are items enough to be paginated.

## Why?
When there is only one page, there is no need to show the component to the users since they can't interact with them.