### PR TITLE
feat(picker-starter): keep only multi-selection filter

### DIFF
--- a/picker-starter/src/data/products.ts
+++ b/picker-starter/src/data/products.ts
@@ -666,13 +666,6 @@ export const getProductOptions: OptionsQuery = async () => {
 
   const response: MultiOption[] = [
     {
-      type: 'single',
-      label: 'Category',
-      options: options,
-      defaultValue: undefined,
-      name: 'category',
-    },
-    {
       type: 'multi',
       options: options,
       defaultValue: [],
@@ -691,13 +684,6 @@ export const queryProducts: ItemQuery = async ({
   perPage,
   userOptions,
 }) => {
-  const matchCategory =
-    (categoryName: undefined | string) => (product: MockProduct) => {
-      if (typeof categoryName === 'undefined') {
-        return true
-      }
-      return product.category === categoryName
-    }
   const matchCategories =
     (categoryNames: string[]) => (product: MockProduct) => {
       if (categoryNames.length === 0) {
@@ -709,7 +695,6 @@ export const queryProducts: ItemQuery = async ({
     }
 
   const allSearchResults = products
-    .filter(matchCategory(userOptions['category'] as string | undefined))
     .filter(matchCategories(userOptions['categoryMulti'] as string[]))
     .filter(matchItem(searchTerm))
 


### PR DESCRIPTION
Issue: EXT-2118

## What?
This PR removes the `Category` filter and keeps only the filter for `Categories` (multi-selection)

## Why?

Having two comboboxes for filtering `categories` at the end doesn't make so much sense and they also don't work well together.

To exemplify the possibility of having a `single-selection` and a `multi-selection` filter, we don't need to create both of them, we can keep only the multi-selection one and document the other (single-selection) in other ways.