### PR TITLE
refactor(picker-starter): replace the term product(s) with item(s)

### DIFF
--- a/picker-starter/src/components/ItemPicker/ItemPicker.vue
+++ b/picker-starter/src/components/ItemPicker/ItemPicker.vue
@@ -163,10 +163,11 @@ export default {
       const res = await this.itemService
         .query(this.queryState.query)
         .catch((error) => error)
+
       if (res instanceof Error) {
         this.notify({
-          title: 'Failed to fetch Products',
-          description: 'Something went wrong when fetching products.',
+          title: `Failed to fetch ${this.itemService.label}`,
+          description: `Something went wrong when fetching ${this.itemService.label}.`,
           error: new Error(res),
         })
         this.dispatch({

--- a/picker-starter/src/core/basket/BasketItem.ts
+++ b/picker-starter/src/core/basket/BasketItem.ts
@@ -6,8 +6,4 @@ export type BasketItem<Type extends string = string> = {
   description: string | undefined
 }
 
-export type ProductItem = BasketItem<'product'> & {
-  sku: string | undefined
-}
-
 export type CategoryItem = BasketItem<'category'>

--- a/picker-starter/src/core/matchItem/matchItem.test.ts
+++ b/picker-starter/src/core/matchItem/matchItem.test.ts
@@ -2,7 +2,7 @@ import { matchItem } from './matchItem'
 import { BasketItem } from '../'
 
 const templateItem: BasketItem = {
-  type: 'product',
+  type: 'item',
   id: '123',
   description: undefined,
   image: undefined,

--- a/picker-starter/src/data/index.ts
+++ b/picker-starter/src/data/index.ts
@@ -1,2 +1,2 @@
 export * from './categories'
-export * from './products'
+export * from './items'

--- a/picker-starter/src/data/items.ts
+++ b/picker-starter/src/data/items.ts
@@ -3,8 +3,8 @@ import {
   FilterList,
   FilterItem,
   FilterOption,
-  ProductItem,
   matchItem,
+  BasketItem,
 } from '@/core'
 import {
   compareName,
@@ -15,7 +15,7 @@ import {
 } from '@/utils'
 import { categoryMockAssets } from './categories'
 
-export type TmpProduct = {
+export type TempItem = {
   id: number
   filename: string | undefined
   description?: string
@@ -23,7 +23,7 @@ export type TmpProduct = {
 }
 
 // Temporary object, just so that we can save some lines of code
-export const tmpAssets: TmpProduct[] = [
+export const tmpAssets: TempItem[] = [
   {
     id: 4997256,
     filename:
@@ -635,28 +635,32 @@ const getNameFromImage = (filename: string): string | undefined => {
   return imageName?.split('.')?.[0]?.split('-')?.map(capitalizeWord)?.join(' ')
 }
 
-export type MockProduct = ProductItem & {
+export type Item = BasketItem<'item'> & {
+  sku: string | undefined
+}
+
+export type MockItem = Item & {
   category: string | undefined
 }
 
-export const products: MockProduct[] = tmpAssets
-  .map((mockProduct) => {
-    const { filename, id, description } = mockProduct
+export const items: MockItem[] = tmpAssets
+  .map((mockItems) => {
+    const { filename, id, description } = mockItems
     const name = filename && getNameFromImage(filename)
 
     return {
-      type: 'product',
+      type: 'item',
       id: `${id}`,
       name: name ?? 'Without image',
       image: filename && getImage(filename),
       sku: `sku-${id}`,
       description,
-      category: mockProduct.category,
-    } as MockProduct
+      category: mockItems.category,
+    } as MockItem
   })
   .sort(compareName)
 
-export const getProductFilters: FilterList = async () => {
+export const getItemFilters: FilterList = async () => {
   const options: FilterOption[] = categoryMockAssets.map<FilterOption>(
     (category) => {
       return {
@@ -680,23 +684,20 @@ export const getProductFilters: FilterList = async () => {
   return delayed(randomDelay(), response)
 }
 
-export const queryProducts: ItemQuery = async ({
+export const queryItems: ItemQuery = async ({
   searchTerm,
   page,
   perPage,
   filterSelection,
 }) => {
-  const matchCategories =
-    (categoryNames: string[]) => (product: MockProduct) => {
-      if (categoryNames.length === 0) {
-        return true
-      }
-      return categoryNames.some(
-        (categoryName) => product.category === categoryName,
-      )
+  const matchCategories = (categoryNames: string[]) => (items: MockItem) => {
+    if (categoryNames.length === 0) {
+      return true
     }
+    return categoryNames.some((categoryName) => items.category === categoryName)
+  }
 
-  const allSearchResults = products
+  const allSearchResults = items
     .filter(matchCategories(filterSelection['categoryMulti'] as string[]))
     .filter(matchItem(searchTerm))
 

--- a/picker-starter/src/picker.config.ts
+++ b/picker-starter/src/picker.config.ts
@@ -1,4 +1,4 @@
-import { getProductFilters, queryCategories, queryProducts } from '@/data'
+import { getItemFilters, queryCategories, queryItems } from '@/data'
 import { defineConfig } from '@/core'
 import { StoryblokIcon } from './components'
 
@@ -24,10 +24,10 @@ export default defineConfig((options) => {
     },
     tabs: [
       {
-        name: 'product',
-        label: 'Products',
-        query: queryProducts,
-        getFilters: getProductFilters,
+        name: 'items',
+        label: 'Items',
+        query: queryItems,
+        getFilters: getItemFilters,
       },
       {
         name: 'category',


### PR DESCRIPTION
Issue: EXT-2119

## What?
Remove the term `products` for a more generic one.

## Why?

The idea of this Starter is to be used in a wider context than just for `e-commerce` projects, so rather than using `products` let's replace it with `items` since it's a more generic term.