### PR TITLE
refactor(picker-starter): remove categories tab

### DIFF
--- a/picker-starter/src/core/basket/BasketItem.ts
+++ b/picker-starter/src/core/basket/BasketItem.ts
@@ -5,5 +5,3 @@ export type BasketItem<Type extends string = string> = {
   image: string | undefined
   description: string | undefined
 }
-
-export type CategoryItem = BasketItem<'category'>

--- a/picker-starter/src/data/categories.ts
+++ b/picker-starter/src/data/categories.ts
@@ -1,6 +1,3 @@
-import { CategoryItem, ItemQuery } from '@/core'
-import { compareName, delayed, getPage, randomDelay } from '@/utils'
-
 export type MockCategory = {
   name: string
   description?: string
@@ -41,29 +38,3 @@ export const categoryMockAssets: MockCategory[] = [
     description: 'Take care of yourself',
   },
 ]
-
-const allCategories: CategoryItem[] = categoryMockAssets
-  .map(
-    (it) =>
-      ({
-        type: 'category',
-        id: it.name,
-        description: undefined,
-        image: undefined,
-        ...it,
-      }) as CategoryItem,
-  )
-  .sort(compareName)
-
-export const queryCategories: ItemQuery = async ({ page, perPage }) => {
-  const paginatedResults = getPage(allCategories, page, perPage)
-  const response = {
-    items: paginatedResults,
-    pageInfo: {
-      totalCount: allCategories.length,
-    },
-  }
-
-  // It mimics an API call by adding a delay before return the data.
-  return delayed(randomDelay(), response)
-}

--- a/picker-starter/src/picker.config.ts
+++ b/picker-starter/src/picker.config.ts
@@ -1,4 +1,4 @@
-import { getItemFilters, queryCategories, queryItems } from '@/data'
+import { getItemFilters, queryItems } from '@/data'
 import { defineConfig } from '@/core'
 import { StoryblokIcon } from './components'
 
@@ -28,11 +28,6 @@ export default defineConfig((options) => {
         label: 'Items',
         query: queryItems,
         getFilters: getItemFilters,
-      },
-      {
-        name: 'category',
-        label: 'Categories',
-        query: queryCategories,
       },
     ],
   }


### PR DESCRIPTION
Issue: EXT-2134

## What?
Remove the category tab from the Picker Starter

## Why?

The idea is to keep this starter as simple as possible and as the `categories tab` didn't add any new concept, removing it would make more sense.

![remove-category-before](https://github.com/storyblok/field-type-examples/assets/1240591/39997fca-a14d-4f2a-9470-afbc0ac6ffcf)
![remove-category-after](https://github.com/storyblok/field-type-examples/assets/1240591/2086f9cb-85cd-4d61-ab13-a3fe6ff8d1cf)

