### PR TITLE
fix(picker-starter): fix image size and list alignment

### DIFF
--- a/picker-starter/src/components/AddAssetButton/AddAssetButton.vue
+++ b/picker-starter/src/components/AddAssetButton/AddAssetButton.vue
@@ -3,7 +3,7 @@
     class="plugin-add-item-big-button"
     @click.prevent="handleClick"
   >
-    <CartListItemImageContainer>
+    <CartListItemImageContainer class="plugin-add-item-big-button__container">
       <SbIcon name="block-image" />
     </CartListItemImageContainer>
     <span class="plugin-add-item-big-button__label">
@@ -69,5 +69,10 @@ export default {
   color: #1b243f;
   font-size: 1.4rem;
   font-weight: 500;
+}
+
+.plugin-add-item-big-button__container {
+  height: 80px;
+  min-width: 106px;
 }
 </style>

--- a/picker-starter/src/components/CartListItemImageContainer/CartListItemImageContainer.vue
+++ b/picker-starter/src/components/CartListItemImageContainer/CartListItemImageContainer.vue
@@ -18,8 +18,9 @@ export default {
   overflow: hidden;
   align-items: center;
   background-color: #eff1f3;
-  height: 80px;
-  min-width: 106px;
+  border: 1px solid #eff1f3;
+  max-height: 80px;
+  max-width: 106px;
   border-radius: 5px;
 }
 </style>


### PR DESCRIPTION
Issue: EXT-2144

## What?
Fix the alignment of the selected items (added to the basket)

## Why?
To improve the UX

**Before**:
![image](https://github.com/storyblok/field-type-examples/assets/1240591/678468ee-ead1-41d4-b92d-47bcb1e76c7e)

**After**:
![result-fix](https://github.com/storyblok/field-type-examples/assets/1240591/6c74695d-4de4-437a-8c62-08676b873706)
