### PR TITLE
chore(common): update cli version when running the deploy script

### DIFF
--- a/folder-selection/package.json
+++ b/folder-selection/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "deploy": "npm run build && npx @storyblok/field-plugin-cli@beta deploy"
+    "deploy": "npm run build && npx @storyblok/field-plugin-cli@latest deploy"
   },
   "dependencies": {
     "@emotion/react": "^11.11.1",

--- a/hosted-plugin/package.json
+++ b/hosted-plugin/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "deploy": "npm run build && npx @storyblok/field-plugin-cli@beta deploy"
+    "deploy": "npm run build && npx @storyblok/field-plugin-cli@latest deploy"
   },
   "dependencies": {
     "@storyblok/field-plugin": "0.0.1-beta.4",

--- a/star-rating/package.json
+++ b/star-rating/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vue-tsc && vite build",
     "preview": "vite preview",
-    "deploy": "npm run build && npx @storyblok/field-plugin-cli@beta deploy"
+    "deploy": "npm run build && npx @storyblok/field-plugin-cli@latest deploy"
   },
   "dependencies": {
     "@storyblok/field-plugin": "0.0.1-beta.2",

--- a/tags/package.json
+++ b/tags/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "deploy": "npm run build && npx @storyblok/field-plugin-cli@beta deploy"
+    "deploy": "npm run build && npx @storyblok/field-plugin-cli@latest deploy"
   },
   "dependencies": {
     "@emotion/react": "^11.11.1",


### PR DESCRIPTION
Issue: EXT-2175

## What?
Update the version of the CLI used when deploying the plugin from `beta` to `latest`.

## Why?
Using the latest version, we're going to be able to publish the plugin right after the deployment happens.
Currently, using the `beta`, we need to publish it manually after the deployment happens.
