### PR TITLE
fix: load more button appearing even when there is no result to show

### DIFF
--- a/picker-starter/src/components/ItemPicker/utils/mixin/showCursorPagination.ts
+++ b/picker-starter/src/components/ItemPicker/utils/mixin/showCursorPagination.ts
@@ -2,5 +2,4 @@ import { State } from '../state/types/State'
 import { isCursorPaginatedResult } from '@/core'
 
 export const showCursorPagination = (state: State): boolean =>
-  isCursorPaginatedResult(state.pageInfo) &&
-  typeof state.pageInfo.endCursor !== 'undefined'
+  isCursorPaginatedResult(state.pageInfo) && state.pageInfo.hasNextPage


### PR DESCRIPTION
## What?

Fix the `load more` button appearing even when there is no result to show.

![image](https://github.com/storyblok/field-type-examples/assets/1240591/de3302e6-b4d7-4b4f-b1fd-ae7667384ada)

PS: The same fix was applied to our Salesforce field plugin.

## Why?

## How to test? (optional)