### PR TITLE
fix: tags component

### DIFF
--- a/tags/src/components/Tag.tsx
+++ b/tags/src/components/Tag.tsx
@@ -10,11 +10,11 @@ import {
 const Tag: FunctionComponent = () => {
   const { data, actions } = useFieldPlugin()
 
-  const [initialValue, setInitialValue] = useState<string[]>([])
-
-  useEffect(() => {
-    setInitialValue(parseJsonValue(data.options.initialValue))
-  }, [data.options.initialValue])
+  const [initialValue, setInitialValue] = useState<string[]>(
+    Array.isArray(data.content)
+      ? data.content
+      : parseJsonValue(data.options.initialValue)
+  )
 
   useEffect(() => {
     actions.setContent(initialValue)
@@ -33,6 +33,7 @@ const Tag: FunctionComponent = () => {
         <TextField
           variant="outlined"
           placeholder={data.options.placeholder}
+          sx={{ background: '#fff' }}
           {...params}
         />
       )}


### PR DESCRIPTION


Issue: SHAPE-8378

## What?

With this PR I changed a little the way the initial value is set, in the current implementation we a only checking the `data.options.initialValue` that is a value that the user can define as a default, however we are not considering the `data.content` that is the actual value of the plugin, because of it when we load the plugin on a story it is discarding the value that is saved on the story.

Current 

https://github.com/user-attachments/assets/de79861e-b3f7-4083-81a5-a473131c5537


With this fix

https://github.com/user-attachments/assets/a54d9973-b6bb-4bf7-b66e-c7014ec0f98c


I also changed the background of the `TextField`, because it is transparent in the current implementation.

| Current  | With this fix |
| ------------- | ------------- |
| ![Screenshot 2025-02-05 at 13 26 05](https://github.com/user-attachments/assets/ad185567-7eb8-4f17-9d1c-bf44f94352e9) |  <img width="925" alt="Screenshot 2025-02-05 at 13 43 49" src="https://github.com/user-attachments/assets/c95efb54-7ef8-4af6-812d-46483b89336b" /> |

## Why?

This will avoid lost the data saved

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
## How to test? (optional)
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->