### PR TITLE
fix: tags component

### DIFF
--- a/tags/README.md
+++ b/tags/README.md
@@ -66,6 +66,9 @@ Example output:
 
 ```json
 {
-  "fieldname": ["AUS", "BRA", "FRA", "SWE", "ITA"]
+  "fieldname": {
+    "value": ["AUS", "BRA", "FRA", "SWE", "ITA"],
+    "plugin": "storyblok-tags"
+  }
 }
 ```

--- a/tags/src/components/Tag.tsx
+++ b/tags/src/components/Tag.tsx
@@ -10,14 +10,19 @@ import {
 const Tag: FunctionComponent = () => {
   const { data, actions } = useFieldPlugin()
 
+  const contentValue = (data.content as { value: string[] }).value
+
   const [initialValue, setInitialValue] = useState<string[]>(
-    Array.isArray(data.content)
-      ? data.content
-      : parseJsonValue(data.options.initialValue)
+    Array.isArray(contentValue)
+      ? contentValue
+      : parseJsonValue(data.options.initialValue),
   )
 
   useEffect(() => {
-    actions.setContent(initialValue)
+    actions.setContent({
+      value: initialValue,
+      plugin: "storyblok-tags",
+    })
   }, [initialValue])
 
   return (


### PR DESCRIPTION
Issue: https://storyblok.atlassian.net/browse/SHAPE-8586

## What?

Change the plugin schema value to be compatible with the old plugin version

## Why?

This version of the plugin is give an error because it changes the schema of the value, before it was an object but in this version it is an array making the user that already have stories with the old format lost their content.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
## How to test? (optional)
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->