### PR TITLE
chore: update README.md with deprecation moved to monorepo warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 
 # Field-type Examples
 
+> ⚠️ **DEPRECATION NOTICE**: Moved to monorepo ⚠️
+>
+> This package has been moved to the new [pluginsblok](https://github.com/storyblok/pluginsblok) monorepo to the [apps/field-plugins](https://github.com/storyblok/pluginsblok/tree/main/apps/field-plugins). For any new Issues or Pull Requests, go to the new repository and add the label `field-types-examples`.
+>
+
 A collection of field-types for Storyblok created by the community. Read more about creating field-types [here](https://www.storyblok.com/docs/plugins/field-type)
 
 <!-- AUTO-GENERATED-CONTENT:START (TOC:collapse=true&collapseText=Table of Content) -->


### PR DESCRIPTION
Issue: [SHAPE-11630](https://github.com/storyblok/app-extension-auth/pull/99#:~:text=Issue%3A-,SHAPE%2D11630,-What%3F)

## What?

- Add a deprecation warning to guide users to the new repository before archiving this one.

## Why?

- We are now using the pluginsblok for all OSS development, and this repository has been moved there.

[SHAPE-11630]: https://storyblok.atlassian.net/browse/SHAPE-11630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ